### PR TITLE
save service state in daemon

### DIFF
--- a/asteroidsyncservice/watch.h
+++ b/asteroidsyncservice/watch.h
@@ -65,11 +65,10 @@ private:
 
 private slots:
     void dataChanged();
-    void timeServiceUp();
-    void serviceDown();
+    void statusTimeService();
     void batteryServiceReady();
     void batteryLevelRefresh(quint8 batLvl);
-    void notifyServiceUp();
+    void statusNotifyService();
 
 private:
     QDBusObjectPath m_path;

--- a/asteroidsyncserviced/dbusinterface.cpp
+++ b/asteroidsyncserviced/dbusinterface.cpp
@@ -37,9 +37,18 @@ DBusWatch::DBusWatch(Watch *watch, WatchesManager* wm, QObject *parent): QObject
 
     connect(m_batteryService, SIGNAL(ready()), this, SIGNAL(BatteryServiceReady()));    
     connect(m_batteryService, SIGNAL(levelChanged(quint8)), this, SIGNAL(LevelChanged(quint8)));
-    connect(m_timeService, SIGNAL(ready()), this, SIGNAL(TimeServiceReady()));
-    connect(m_notificationService, SIGNAL(ready()), this, SIGNAL(NotificationServiceReady()));
-    connect(wm, SIGNAL(disconnected()), this, SIGNAL(Disconnected()));
+    connect(m_timeService, SIGNAL(ready()), this, SLOT(TimeServiceReady()));
+    connect(m_notificationService, SIGNAL(ready()), this, SLOT(NotifyServiceReady()));
+    connect(wm, SIGNAL(disconnected()), this, SLOT(Disconnected()));
+}
+
+void DBusWatch::Disconnected()
+{
+    m_timeServiceReady = false;
+    emit TimeServiceChanged();
+
+    m_notifyServiceReady = false;
+    emit NotifyServiceChanged();
 }
 
 void DBusWatch::SelectWatch()
@@ -70,6 +79,28 @@ void DBusWatch::RequestScreenshot()
 void DBusWatch::WeatherSetCityName(QString cityName)
 {
     m_weatherService->setCity(cityName);
+}
+
+void DBusWatch::TimeServiceReady()
+{
+    m_timeServiceReady = true;
+    emit TimeServiceChanged();
+}
+
+bool DBusWatch::StatusTimeService()
+{
+    return m_timeServiceReady;
+}
+
+void DBusWatch::NotifyServiceReady()
+{
+    m_notifyServiceReady = true;
+    emit NotifyServiceChanged();
+}
+
+bool DBusWatch::StatusNotifyService()
+{
+    return m_notifyServiceReady;
 }
 
 void DBusWatch::SetTime(QDateTime t)

--- a/asteroidsyncserviced/dbusinterface.h
+++ b/asteroidsyncserviced/dbusinterface.h
@@ -37,12 +37,11 @@ public:
 
 signals:
     void Connected();
-    void Disconnected();
 
     void LevelChanged(quint8);
-    void TimeServiceReady();
+    void TimeServiceChanged();
     void BatteryServiceReady();
-    void NotificationServiceReady();
+    void NotifyServiceChanged();
 
 public slots:
     void SelectWatch();
@@ -51,11 +50,18 @@ public slots:
     QString Name() const;
 
     quint8 BatteryLevel();
+    bool StatusTimeService();
+    bool StatusNotifyService();
     void RequestScreenshot();
     void WeatherSetCityName(QString cityName);
     void SetTime(QDateTime t);
     void SetVibration(QString v);
     void SendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary);
+
+private slots:
+    void TimeServiceReady();
+    void NotifyServiceReady();
+    void Disconnected();
 
 private:
     Watch *m_watch;
@@ -67,6 +73,8 @@ private:
     WeatherService *m_weatherService;
     TimeService *m_timeService;
     NotificationService *m_notificationService;
+    bool m_timeServiceReady = false;
+    bool m_notifyServiceReady = false;
 };
 
 class DBusInterface : public QObject


### PR DESCRIPTION
This is a redesign. In the actual version, the status of all services are stored in the app. If i close and reopen the app, the status of the service is lost.
So i changed this, save the status in the daemon and the app part can get the actual status of the service on app start or on service state changed.