### PR TITLE
Create also non-existing parent directories

### DIFF
--- a/asteroidsyncservice/watch.cpp
+++ b/asteroidsyncservice/watch.cpp
@@ -177,7 +177,7 @@ void Watch::setScreenshotFileInfo(const QString fileInfo)
 bool Watch::createDir(const QDir path)
 {
     if(!path.exists()) {
-        return path.mkdir(path.path());
+        return path.mkpath(path.path());
     } else {
         return true;
     }


### PR DESCRIPTION
Some people have reported that after receiving the screenshot, the file is not saved.
The problem is that missing parent directories are not created.

That should be fixed by this changes.