### PR TITLE
Update dependancies and use harbour prefix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/AsteroidOS/libasteroid
 [submodule "asteroidsyncserviced/libwatchfish"]
 	path = asteroidsyncserviced/libwatchfish
-	url = https://git.javispedro.com/libwatchfish.git
+	url = git@github.com:piggz/libwatchfish.git

--- a/asteroidsyncservice/asteroidsyncservice.pro
+++ b/asteroidsyncservice/asteroidsyncservice.pro
@@ -9,7 +9,7 @@ uri = org.asteroid.syncservice
 
 contains(CONFIG, telescope) {
     include(telescope.pri)
-} 
+}
 
 contains(CONFIG, starfish) {
     include(starfish.pri)

--- a/asteroidsyncservice/platforms/sailfishos/servicecontrol.h
+++ b/asteroidsyncservice/platforms/sailfishos/servicecontrol.h
@@ -23,7 +23,7 @@
 #include <QDBusInterface>
 #include <QObject>
 
-static const QString SYNCSERVICED_SYSTEMD_UNIT("asteroidsyncserviced.service");
+static const QString SYNCSERVICED_SYSTEMD_UNIT("harbour-asteroidsyncserviced.service");
 
 class ServiceControl : public QObject
 {

--- a/asteroidsyncserviced/asteroidsyncserviced.pro
+++ b/asteroidsyncserviced/asteroidsyncserviced.pro
@@ -4,7 +4,13 @@ QT -= gui
 include(../version.pri)
 include(libasteroid/libasteroid.pri)
 
-TARGET = asteroidsyncserviced
+contains(CONFIG, telescope) {
+    TARGET = asteroidsyncserviced
+}
+
+contains(CONFIG, starfish) {
+    TARGET = harbour-asteroidsyncserviced
+}
 
 CONFIG += c++11
 CONFIG += console

--- a/asteroidsyncserviced/harbour-asteroidsyncserviced.service
+++ b/asteroidsyncserviced/harbour-asteroidsyncserviced.service
@@ -4,7 +4,7 @@ Requires=dbus.socket bluetooth.target booster-qt5.service
 After=pre-user-session.target lipstick.service dbus.socket bluetooth.target booster-qt5.service
 
 [Service]
-ExecStart=/usr/bin/invoker -o --type=qt5 /usr/bin/asteroidsyncserviced
+ExecStart=/usr/bin/invoker -o --type=qt5 /usr/bin/harbour-asteroidsyncserviced
 Restart=always
 
 [Install]

--- a/asteroidsyncserviced/starfish.pri
+++ b/asteroidsyncserviced/starfish.pri
@@ -2,10 +2,13 @@ DEFINES += SAILFISHOS_PLATFORM
 
 WATCHFISH_FEATURES = notificationmonitor walltime music
 
-SUBDIRS += libwatchfish
+include(libwatchfish/libwatchfish.pri)
 
 PKGCONFIG += qt5-boostable
 
 SOURCES += platforms/sailfishos/sailfishplatform.cpp
 
 HEADERS += platforms/sailfishos/sailfishplatform.h
+
+DISTFILES += \
+    $$PWD/harbour-asteroidsyncserviced.service


### PR DESCRIPTION
Updates the libwatchfish dependency to use Piggz updated/fixed fork.
Additionally tweaks the background service to use the "harbour-" prefix.