### PR TITLE
Improve SailfishOS build

### DIFF
--- a/asteroidsyncservice.pro
+++ b/asteroidsyncservice.pro
@@ -1,3 +1,5 @@
+include(../version.pri)
+
 TEMPLATE = subdirs
 SUBDIRS = asteroidsyncservice asteroidsyncserviced
 OTHER_FILES += \

--- a/asteroidsyncservice/asteroidsyncservice.pro
+++ b/asteroidsyncservice/asteroidsyncservice.pro
@@ -2,7 +2,7 @@ TEMPLATE = lib
 TARGET = asteroidsyncserviceplugin
 QT += qml quick dbus
 CONFIG += qt plugin
-include(../version.pri)
+include(../../version.pri)
 
 TARGET = $$qtLibraryTarget($$TARGET)
 uri = org.asteroid.syncservice

--- a/asteroidsyncserviced/asteroidsyncserviced.pro
+++ b/asteroidsyncserviced/asteroidsyncserviced.pro
@@ -1,7 +1,7 @@
 QT += core bluetooth dbus
 QT -= gui
 
-include(../version.pri)
+include(../../version.pri)
 include(libasteroid/libasteroid.pri)
 
 contains(CONFIG, telescope) {

--- a/asteroidsyncserviced/bluez/bluezclient.h
+++ b/asteroidsyncserviced/bluez/bluezclient.h
@@ -30,7 +30,9 @@
 #include "bluez_adapter1.h"
 #include "bluez_agentmanager1.h"
 
+#ifndef NOTIF_UUID
 #define NOTIF_UUID "00009071-0000-0000-0000-00a57e401d05"
+#endif
 
 class Device {
 public:

--- a/rpm/asteroidsyncservice.spec
+++ b/rpm/asteroidsyncservice.spec
@@ -40,8 +40,9 @@ Support for AsteroidOS watches in SailfishOS.
 rm -rf %{buildroot}
 %qmake5_install
 
-mkdir -p %{buildroot}%{_libdir}/systemd/user/user-session.target.wants
-ln -s ../asteroidsyncserviced.service %{buildroot}%{_libdir}/systemd/user/user-session.target.wants/
+echo %{_userunitdir}
+mkdir -p %{buildroot}%{_userunitdir}/user-session.target.wants
+ln -s ../asteroidsyncserviced.service %{buildroot}%{_userunitdir}/user-session.target.wants/
 
 %post
 grep -q "^/usr/bin/asteroidsyncserviced" /usr/share/mapplauncherd/privileges || echo "/usr/bin/asteroidsyncserviced,cehlmnpu" >> /usr/share/mapplauncherd/privileges
@@ -51,6 +52,6 @@ su nemo -c 'systemctl --user try-restart asteroidsyncserviced.service'
 %files
 %defattr(-,root,root,-)
 %{_bindir}
-%{_libdir}/systemd/user/%{name}d.service
-%{_libdir}/systemd/user/user-session.target.wants/%{name}d.service
+%{_userunitdir}/%{name}d.service
+%{_userunitdir}/user-session.target.wants/%{name}d.service
 %{_libdir}/qt5/qml/org/asteroid/syncservice


### PR DESCRIPTION
Just some `version.pri` include fixes and `systemd` path fixes in the form of `rpm` macros: use `%{_userunitdir}` instead of `%{_libdir}` which points to `/usr/lib64` which doesn't work at least on my Xperia 10 II, and the RPM build fails, too.

About the `#ifndef` part: I really don't know why I had to put it in, since the file itself is in `#ifndef` block... It was originally declared in `common.h:30`, which was identical with this one, so I made the quick and dirty fix (:

Tested with Sony Xperia XA2 Ultra (armv7hl) and Sony Xperia 10 II (aarch64) which both are now able to connect to the watch (LG G Watch R aka. lenok), so that's a start!

This PR is accompanied with a PR over at [Starfish](https://github.com/AsteroidOS/starfish/issues/4).