### PR TITLE
Improve SailfishOS build, take 3

### DIFF
--- a/asteroidsyncservice.pro
+++ b/asteroidsyncservice.pro
@@ -1,3 +1,5 @@
+include(../version.pri)
+
 TEMPLATE = subdirs
 SUBDIRS = asteroidsyncservice asteroidsyncserviced
 OTHER_FILES += \

--- a/asteroidsyncservice/asteroidsyncservice.pro
+++ b/asteroidsyncservice/asteroidsyncservice.pro
@@ -2,7 +2,7 @@ TEMPLATE = lib
 TARGET = asteroidsyncserviceplugin
 QT += qml quick dbus
 CONFIG += qt plugin
-include(../version.pri)
+include(../../version.pri)
 
 TARGET = $$qtLibraryTarget($$TARGET)
 uri = org.asteroid.syncservice

--- a/asteroidsyncserviced/asteroidsyncserviced.pro
+++ b/asteroidsyncserviced/asteroidsyncserviced.pro
@@ -1,7 +1,7 @@
 QT += core bluetooth dbus
 QT -= gui
 
-include(../version.pri)
+include(../../version.pri)
 include(libasteroid/libasteroid.pri)
 
 contains(CONFIG, telescope) {

--- a/asteroidsyncserviced/bluez/bluezclient.cpp
+++ b/asteroidsyncserviced/bluez/bluezclient.cpp
@@ -19,6 +19,7 @@
 
 #include "bluezclient.h"
 #include "dbus-shared.h"
+#include "../libasteroid/services/common.h"
 
 #include <QDBusConnection>
 #include <QDBusReply>

--- a/asteroidsyncserviced/bluez/bluezclient.h
+++ b/asteroidsyncserviced/bluez/bluezclient.h
@@ -30,8 +30,6 @@
 #include "bluez_adapter1.h"
 #include "bluez_agentmanager1.h"
 
-#define NOTIF_UUID "00009071-0000-0000-0000-00a57e401d05"
-
 class Device {
 public:
     QBluetoothAddress address;

--- a/asteroidsyncserviced/main.cpp
+++ b/asteroidsyncserviced/main.cpp
@@ -33,13 +33,13 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 {
     QCoreApplication a(argc, argv);
 
-    WatchesManager *watchesManager = new WatchesManager();
-    #ifdef UBUNTU_TOUCH_PLATFORM
-      UbuntuPlatform *platform = new UbuntuPlatform(watchesManager);
-    #elif SAILFISHOS_PLATFORM
-      SailfishPlatform *platform = new SailfishPlatform(watchesManager);
-    #endif
-    DBusInterface *dbusInterface = new DBusInterface(watchesManager);
+    WatchesManager watchesManager;
+#ifdef UBUNTU_TOUCH_PLATFORM
+    UbuntuPlatform platform(&watchesManager);
+#elif SAILFISHOS_PLATFORM
+    SailfishPlatform platform(&watchesManager);
+#endif
+    DBusInterface dbusInterface(&watchesManager);
 
     return a.exec();
 }

--- a/rpm/asteroidsyncservice.spec
+++ b/rpm/asteroidsyncservice.spec
@@ -40,17 +40,17 @@ Support for AsteroidOS watches in SailfishOS.
 rm -rf %{buildroot}
 %qmake5_install
 
-mkdir -p %{buildroot}%{_libdir}/systemd/user/user-session.target.wants
-ln -s ../asteroidsyncserviced.service %{buildroot}%{_libdir}/systemd/user/user-session.target.wants/
+mkdir -p %{buildroot}%{_userunitdir}/user-session.target.wants
+ln -s ../asteroidsyncserviced.service %{buildroot}%{_userunitdir}/user-session.target.wants/
 
 %post
-grep -q "^/usr/bin/asteroidsyncserviced" /usr/share/mapplauncherd/privileges || echo "/usr/bin/asteroidsyncserviced,cehlmnpu" >> /usr/share/mapplauncherd/privileges
-su nemo -c 'systemctl --user daemon-reload'
-su nemo -c 'systemctl --user try-restart asteroidsyncserviced.service'
+echo "/usr/bin/asteroidsyncserviced,cehlmnpu" > /usr/share/mapplauncherd/privileges.d/harbour-asteroidsyncserviced.privileges
+systemctl-user daemon-reload
+systemctl-user try-restart asteroidsyncserviced.service
 
 %files
 %defattr(-,root,root,-)
 %{_bindir}
-%{_libdir}/systemd/user/%{name}d.service
-%{_libdir}/systemd/user/user-session.target.wants/%{name}d.service
+%{_userunitdir}/%{name}d.service
+%{_userunitdir}/user-session.target.wants/%{name}d.service
 %{_libdir}/qt5/qml/org/asteroid/syncservice


### PR DESCRIPTION
Just some `version.pri` include fixes and `systemd` path fixes in the form of `rpm` macros: use `%{_userunitdir}` instead of `%{_libdir}` which points to `/usr/lib64` which doesn't work at least on my Xperia 10 II, and the RPM build fails, too.

Included `common.h` as discussed in the previous PR :)

**New!** Properly delete objects in `main.cpp`, and get rid of "unused variables" warning in the process.

**New!** Use `systemctl-user` instead of `su nemo -c 'systemctl --user [...]` which was made for exactly this purpose. The script is provided by Jolla and exists at least as early as SFOS 3.4, so it's safe to use. The script gets the current username, which nowadays can't be assumed to be neither `nemo` nor `defaultuser`.

**New!** Use `/usr/share/mapplauncherd/privileges.d/harbour-asteroidsyncserviced.privileges` instead of `/usr/share/mapplauncherd/privileges` which doesn't exist anymore.

Tested with Sony Xperia XA2 Ultra (armv7hl) and Sony Xperia 10 II (aarch64) which both are now able to connect to the watch (LG G Watch R aka. lenok), so that's a start!

This PR is accompanied with a PR over at [Starfish](https://github.com/AsteroidOS/starfish/issues/4).