### PR TITLE
Fix include directory path.

### DIFF
--- a/asteroidsyncserviced/bluez/bluezclient.cpp
+++ b/asteroidsyncserviced/bluez/bluezclient.cpp
@@ -19,7 +19,7 @@
 
 #include "bluezclient.h"
 #include "dbus-shared.h"
-#include "../libasteroid/services/common.h"
+#include "services/common.h"
 
 #include <QDBusConnection>
 #include <QDBusReply>


### PR DESCRIPTION
When the project was converted to CMake, the include paths were changed
and simplified.  This file was inadvertently reverted to use the old
path which no longer works with CMake.

Signed-off-by: Ed Beroset <beroset@ieee.org>