### PR TITLE
Remove unneeded Qt bits from CMakeLists for plugin

### DIFF
--- a/asteroidsyncservice/CMakeLists.txt
+++ b/asteroidsyncservice/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.15)
-find_package(QT NAMES Qt5 COMPONENTS Core Bluetooth DBus Qml Quick REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Bluetooth DBus Qml Quick REQUIRED)
+find_package(QT NAMES Qt5 COMPONENTS DBus Qml REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS DBus Qml REQUIRED)
 add_library(asteroidsyncserviceplugin SHARED syncservice_plugin.cpp watch.cpp watches.cpp ${PLATFORM_SOURCE_DIR}/servicecontrol.cpp)
 set_target_properties(asteroidsyncserviceplugin PROPERTIES AUTOMOC ON)
 target_include_directories(asteroidsyncserviceplugin PRIVATE ${PLATFORM_SOURCE_DIR})
 target_compile_features(asteroidsyncserviceplugin PUBLIC cxx_std_17)
-target_link_libraries(asteroidsyncserviceplugin PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Bluetooth Qt${QT_VERSION_MAJOR}::DBus Qt${QT_VERSION_MAJOR}::Qml Qt${QT_VERSION_MAJOR}::Quick asteroid)
+target_link_libraries(asteroidsyncserviceplugin PRIVATE Qt${QT_VERSION_MAJOR}::DBus Qt${QT_VERSION_MAJOR}::Qml)
 
 # Installation paths
 get_target_property(REAL_QMAKE_EXECUTABLE ${Qt5Core_QMAKE_EXECUTABLE}


### PR DESCRIPTION
The Qt::Bluetooth and Qt::Quick libraries do not need to be linked with
the plugin and the Qt::Core library is linked implicitly and so none of
them need to be included in CMakeLists.txt