### PR TITLE
Add volume controls to the daemon

### DIFF
--- a/asteroidsyncserviced/platforms/ubuntutouch/platform.h
+++ b/asteroidsyncserviced/platforms/ubuntutouch/platform.h
@@ -32,6 +32,7 @@ private slots:
     void onNextMusicTitle();
     void onPlayMusicTitle();
     void onPauseMusicTitle();
+    void onMediaVolumeChange(quint8 vol);
 
 private:
     QDBusInterface *m_iface;


### PR DESCRIPTION
This uses the updated version of libasteroid which contains the
previously missing volume controls and adds the appropriate new slot to
connect with a media player.