### PR TITLE
Always pass explicit vibrate setting for notifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(asteroidsyncservice VERSION 1.0.0 
+project(asteroidsyncservice VERSION 2.0.0 
     DESCRIPTION "A synchronization daemon for AsteroidOS watches"
 )
 

--- a/asteroidsyncservice/watch.cpp
+++ b/asteroidsyncservice/watch.cpp
@@ -134,9 +134,9 @@ void Watch::setVibration(QString v)
     m_iface->call("SetVibration", v);
 }
 
-void Watch::sendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary)
+void Watch::sendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary, QString vibration)
 {
-    m_iface->call("SendNotify", id, appName, icon, body, summary);
+    m_iface->call("SendNotify", id, appName, icon, body, summary, vibration);
 }
 
 bool Watch::screenshotServiceReady()

--- a/asteroidsyncservice/watch.h
+++ b/asteroidsyncservice/watch.h
@@ -58,7 +58,7 @@ public:
     Q_INVOKABLE void setTime(QDateTime t);
     bool notificationServiceReady();
     Q_INVOKABLE void setVibration(QString v);
-    Q_INVOKABLE void sendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary);
+    Q_INVOKABLE void sendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary, QString vibration);
     bool weatherServiceReady();
 
 public slots:

--- a/asteroidsyncserviced/dbusinterface.cpp
+++ b/asteroidsyncserviced/dbusinterface.cpp
@@ -119,14 +119,9 @@ void DBusWatch::SetTime(QDateTime t)
     m_timeService->setTime(t);
 }
 
-void DBusWatch::SetVibration(QString v)
+void DBusWatch::SendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary, QString vibration)
 {
-    m_notificationService->setVibration(v);
-}
-
-void DBusWatch::SendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary)
-{
-    m_notificationService->insertNotification("", id, appName, icon, body, summary, NotificationService::Strong);
+    m_notificationService->insertNotification("", id, appName, icon, body, summary, vibration);
 }
 
 void DBusWatch::onScreenshotServiceReady()

--- a/asteroidsyncserviced/dbusinterface.h
+++ b/asteroidsyncserviced/dbusinterface.h
@@ -61,8 +61,7 @@ public slots:
     void RequestScreenshot();
     void WeatherSetCityName(QString cityName);
     void SetTime(QDateTime t);
-    void SetVibration(QString v);
-    void SendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary);
+    void SendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary, QString vibration);
 
 private slots:
     void onTimeServiceReady();

--- a/asteroidsyncserviced/platforms/sailfishos/platform.cpp
+++ b/asteroidsyncserviced/platforms/sailfishos/platform.cpp
@@ -72,7 +72,7 @@ void Platform::newNotification(watchfish::Notification *notification)
 {
     if (!notification->category().endsWith(".group")) {
         connect(notification, SIGNAL(closed(CloseReason)), this, SLOT(onNotificationClosed(CloseReason)));
-        m_notificationService->insertNotification(notification->appId(), notification->id(), notification->appName(), "ios-mail", notification->summary(), notification->body(), NotificationService::Strong);
+        m_notificationService->insertNotification(notification->appId(), notification->id(), notification->appName(), "ios-mail", notification->summary(), notification->body(), "strong");
     }
 }
 

--- a/asteroidsyncserviced/platforms/ubuntutouch/platform.cpp
+++ b/asteroidsyncserviced/platforms/ubuntutouch/platform.cpp
@@ -62,7 +62,7 @@ uint Platform::Notify(const QString &app_name, uint replaces_id, const QString &
             qDebug() << __func__ << "Have a phone call notification. Ignoring it..." << app_name << app_icon;
         } else if(m_notificationServiceReady) {
             unsigned int randId = rand() % 100000 + 1;
-            m_notificationService->insertNotification("", randId, encodeAppName(app_name), encodeIcon(app_name), summary, body, m_notificationService->getVibration());
+            m_notificationService->insertNotification("", randId, encodeAppName(app_name), encodeIcon(app_name), summary, body, "normal");
         } else {
             qDebug() << __func__ << "Service not ready";
         }


### PR DESCRIPTION
The current code always sets the vibrate level of notifications to
"Strong" no matter the current setting.  This change causes the client
to respect the currently set vibration settings instead.