### PR TITLE
Expand weather api

### DIFF
--- a/asteroidsyncservice/watch.cpp
+++ b/asteroidsyncservice/watch.cpp
@@ -59,12 +59,13 @@ QString Watch::name()
 
 QString Watch::weatherCityName()
 {
-    return ""; // TODO
+    return m_weatherCityName; 
 }
 
 void Watch::setWeatherCityName(const QString &c)
 {
     m_iface->call("WeatherSetCityName", c);
+    m_weatherCityName = c;
     emit weatherCityNameChanged();
 }
 

--- a/asteroidsyncservice/watch.cpp
+++ b/asteroidsyncservice/watch.cpp
@@ -140,6 +140,11 @@ void Watch::sendNotify(unsigned int id, QString appName, QString icon, QString b
     m_iface->call("SendNotify", id, appName, icon, body, summary, vibration);
 }
 
+void Watch::updateWeather(QString weatherJson)
+{
+    m_iface->call("WeatherSetWeather", weatherJson);
+}
+
 bool Watch::screenshotServiceReady()
 {
     return fetchProperty("StatusScreenshotService").toBool();

--- a/asteroidsyncservice/watch.h
+++ b/asteroidsyncservice/watch.h
@@ -97,6 +97,7 @@ private:
     unsigned int m_scrnProgress = 0;
     QFileInfo m_screenshotFileInfo;
     QString m_screenshotName;
+    QString m_weatherCityName;
 };
 
 #endif // WATCH_H

--- a/asteroidsyncservice/watch.h
+++ b/asteroidsyncservice/watch.h
@@ -59,6 +59,7 @@ public:
     bool notificationServiceReady();
     Q_INVOKABLE void setVibration(QString v);
     Q_INVOKABLE void sendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary, QString vibration);
+    Q_INVOKABLE void updateWeather(QString weatherJson);
     bool weatherServiceReady();
 
 public slots:

--- a/asteroidsyncserviced/dbusinterface.cpp
+++ b/asteroidsyncserviced/dbusinterface.cpp
@@ -36,7 +36,7 @@ DBusWatch::DBusWatch(Watch *watch, WatchesManager* wm, QObject *parent): QObject
     m_timeService = wm->timeService();
     m_notificationService = wm->notificationService();
 
-    connect(m_batteryService, SIGNAL(ready()), this, SIGNAL(BatteryServiceReady()));    
+    connect(m_batteryService, SIGNAL(ready()), this, SIGNAL(BatteryServiceReady()));
     connect(m_batteryService, SIGNAL(levelChanged(quint8)), this, SIGNAL(LevelChanged(quint8)));
     connect(m_timeService, SIGNAL(ready()), this, SLOT(onTimeServiceReady()));
     connect(m_notificationService, SIGNAL(ready()), this, SLOT(onNotifyServiceReady()));

--- a/asteroidsyncserviced/dbusinterface.h
+++ b/asteroidsyncserviced/dbusinterface.h
@@ -60,6 +60,7 @@ public slots:
     bool StatusWeatherService();
     void RequestScreenshot();
     void WeatherSetCityName(QString cityName);
+    void WeatherSetWeather(QString weatherJson);
     void SetTime(QDateTime t);
     void SendNotify(unsigned int id, QString appName, QString icon, QString body, QString summary, QString vibration);
 


### PR DESCRIPTION
This is an alternative approach to the weather PR https://github.com/AsteroidOS/asteroidsyncservice/pull/29.  Instead of having the library contact a weather service to retrieve JSON data, this uses the much simpler approach of changing the interface both the daemon and the QML plugin to accept properly formatted JSON weather data.  It's assumed that a GUI user of these libraries will perform the task of fetching JSON data.

Ultimately, the parsing code from JSON is small and isolated and it's anticipated that the parsing will move entirely to the watch when we have a fix for https://github.com/AsteroidOS/asteroid-btsyncd/issues/22.  That would also allow a WiFi-connected watch to fetch the data itself with minimal changes internal to the watch and no changes to the external interface in the `asteroidsyncservice` project.