### PR TITLE
Send "PlayPause" instead of "Play" to mpris

### DIFF
--- a/asteroidsyncserviced/platforms/ubuntutouch/platform.cpp
+++ b/asteroidsyncserviced/platforms/ubuntutouch/platform.cpp
@@ -114,7 +114,7 @@ void Platform::onNextMusicTitle()
 
 void Platform::onPlayMusicTitle()
 {
-    sendMusicControlCommand("Play");
+    sendMusicControlCommand("PlayPause");
 }
 
 void Platform::onPauseMusicTitle()


### PR DESCRIPTION
This fixes #52 by using PlayPause instead of Play.  In the case that
there was already a title that had been playing and is paused, it will
work as it had.  However, if there is no current title (as when playing
streaming radio stations, for example), sending PlayPause will actually
start the service rather than giving a D-Bus error from the MPRIS
player.