### PR TITLE
Remove conversion in Watch::setScreenshotFileInfo

### DIFF
--- a/asteroidsyncservice/watch.cpp
+++ b/asteroidsyncservice/watch.cpp
@@ -177,7 +177,7 @@ void Watch::setScreenshotFileInfo(const QString fileInfo)
     QFileInfo fInfo(fileInfo);
     if(!createDir(fInfo.dir()))
         qDebug() << "Unable to create directory";
-    m_screenshotFileInfo = fileInfo;
+    m_screenshotFileInfo = fInfo;
 }
 
 bool Watch::createDir(const QDir path)


### PR DESCRIPTION
The Watch::setScreenshotFileInfo is passed a QString which is then converted into a QFileInfo type within the function.  At the end, the m_screenshotFileInfo variable was originally set with the fileInfo string even though it's a QFileInfo type, forcing another conversion. This eliminates that unnecessary conversion by simply using fInfo which is already the correct type.

Signed-off-by: Ed Beroset <beroset@ieee.org>